### PR TITLE
Add get_power_input

### DIFF
--- a/src/hw_mon.rs
+++ b/src/hw_mon.rs
@@ -96,6 +96,11 @@ impl HwMon {
         self.read_power("power1_average")
     }
 
+    /// Gets the instantaneous power (currently) used by the GPU in watts.
+    pub fn get_power_input(&self) -> Result<f64> {
+        self.read_power("power1_input")
+    }
+
     /// Gets the current power cap of the GPU in watts.
     pub fn get_power_cap(&self) -> Result<f64> {
         self.read_power("power1_cap")


### PR DESCRIPTION
The AMDGPU driver supports `power1_input` from Linux Kernel v6.6.  
Note that most AMD GPUs only support either `power1_average` or `power1_input`.

Link: https://www.kernel.org/doc/html/latest/gpu/amdgpu/thermal.html#hwmon-interfaces
Link: https://gitlab.freedesktop.org/drm/amd/-/issues/2897