### PR TITLE
gcn.rs: reverse iteration over sclk and mclk levels

### DIFF
--- a/src/gpu_handle/overdrive/gcn.rs
+++ b/src/gpu_handle/overdrive/gcn.rs
@@ -26,12 +26,12 @@ impl ClocksTable for Table {
         writer: &mut W,
         _previous_table: &ClocksTableGen,
     ) -> Result<()> {
-        for (i, level) in self.sclk_levels.iter().enumerate() {
+        for (i, level) in self.sclk_levels.iter().enumerate().rev() {
             let command = level_command(*level, i, 's');
             writer.write_all(command.as_bytes())?;
         }
 
-        for (i, level) in self.mclk_levels.iter().enumerate() {
+        for (i, level) in self.mclk_levels.iter().enumerate().rev() {
             let command = level_command(*level, i, 'm');
             writer.write_all(command.as_bytes())?;
         }


### PR DESCRIPTION
Writing the table in ascending order (P0 -> P7) can cause the later high P-state writes to be rejected/clamped by the driver because earlier states were still at higher voltages at the moment the write is processed. This manifests as P7 not going below a floor even though the OD table entry is updated.

Reverse iteration (P7 -> P0) over sclk and mclk levels to ensure that when undervolting, each subsequent write never attempts to set a voltage below a previously committed higher P-state voltage, preventing the driver from rejecting the requested value.

Fixes https://github.com/ilya-zlobintsev/LACT/issues/933