### PR TITLE
fix: ignore S index for p-states

### DIFF
--- a/src/gpu_handle/mod.rs
+++ b/src/gpu_handle/mod.rs
@@ -204,59 +204,67 @@ impl GpuHandle {
         T: FromStr,
         <T as FromStr>::Err: Display,
     {
-        self.read_file(kind.filename()).and_then(|content| {
-            let mut levels = Vec::new();
-            let mut active = None;
-            let mut invalid_active = false;
+        self.read_file(kind.filename())
+            .and_then(|content| Self::parse_clock_levels(&content, kind))
+    }
 
-            for mut line in content.trim().split('\n') {
-                if let Some(stripped) = line.strip_suffix('*') {
-                    line = stripped;
+    fn parse_clock_levels<T>(content: &str, kind: PowerLevelKind) -> Result<PowerLevels<T>>
+    where
+        T: FromStr,
+        <T as FromStr>::Err: Display,
+    {
+        let mut levels = Vec::new();
+        let mut active = None;
+        let mut invalid_active = false;
 
-                    if let Some(identifier) = stripped.split(':').next() {
-                        if identifier.trim().eq_ignore_ascii_case("S") {
-                            continue;
-                        }
+        for mut line in content.trim().split('\n') {
+            if let Some(stripped) = line.strip_suffix('*') {
+                line = stripped;
 
-                        if !invalid_active {
-                            if active.is_some() {
-                                active = None;
-                                invalid_active = true;
-                            } else {
-                                let idx = identifier
-                                    .trim()
-                                    .parse()
-                                    .context("Unexpected power level identifier")?;
-                                active = Some(idx);
-                            }
+                if let Some(identifier) = stripped.split(':').next() {
+                    if identifier.trim().eq_ignore_ascii_case("S") {
+                        continue;
+                    }
+
+                    if !invalid_active {
+                        if active.is_some() {
+                            active = None;
+                            invalid_active = true;
+                        } else {
+                            let idx = identifier
+                                .trim()
+                                .parse()
+                                .context("Unexpected power level identifier")?;
+                            active = Some(idx);
                         }
                     }
                 }
-                if let Some(s) = line.split(':').next_back() {
-                    let parse_result = if let Some(suffix) = kind.value_suffix() {
-                        let raw_value = s.trim().to_lowercase();
-                        let value = raw_value.strip_suffix(suffix).ok_or_else(|| {
-                            ErrorKind::ParseError {
+            }
+            if let Some(s) = line.split(':').next_back() {
+                let parse_result = if let Some(suffix) = kind.value_suffix() {
+                    let raw_value = s.trim().to_lowercase();
+                    let value =
+                        raw_value
+                            .strip_suffix(suffix)
+                            .ok_or_else(|| ErrorKind::ParseError {
                                 msg: format!("Level did not have the expected suffix {suffix}"),
                                 line: levels.len() + 1,
-                            }
-                        })?;
-                        T::from_str(value)
-                    } else {
-                        let value = s.trim();
-                        T::from_str(value)
-                    };
+                            })?;
+                    T::from_str(value)
+                } else {
+                    let value = s.trim();
+                    T::from_str(value)
+                };
 
-                    let parsed_value = parse_result.map_err(|err| ErrorKind::ParseError {
-                        msg: format!("Could not deserialize power level value: {err}"),
-                        line: levels.len() + 1,
-                    })?;
-                    levels.push(parsed_value);
-                }
+                let parsed_value = parse_result.map_err(|err| ErrorKind::ParseError {
+                    msg: format!("Could not deserialize power level value: {err}"),
+                    line: levels.len() + 1,
+                })?;
+                levels.push(parsed_value);
             }
+        }
 
-            Ok(PowerLevels { levels, active })
-        })
+        Ok(PowerLevels { levels, active })
     }
 
     impl_get_clocks_levels!(get_core_clock_levels, PowerLevelKind::CoreClock, u64);
@@ -786,5 +794,74 @@ impl CommitHandle {
                 self.file_path.file_name().unwrap()
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GpuHandle, PowerLevelKind, PowerLevels};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn parse_clock_levels_with_suffix() {
+        let levels = GpuHandle::parse_clock_levels::<u64>(
+            "\
+0: 500Mhz
+1: 2124Mhz *",
+            PowerLevelKind::CoreClock,
+        )
+        .unwrap();
+
+        assert_eq!(
+            PowerLevels {
+                levels: vec![500, 2124],
+                active: Some(1),
+            },
+            levels
+        );
+    }
+
+    #[test]
+    fn parse_clock_levels_without_suffix() {
+        let levels = GpuHandle::parse_clock_levels::<String>(
+            "\
+0: 2.5GT/s, x1 310Mhz
+1: 16.0GT/s, x16 619Mhz *",
+            PowerLevelKind::PcieSpeed,
+        )
+        .unwrap();
+
+        assert_eq!(
+            PowerLevels {
+                levels: vec![
+                    "2.5GT/s, x1 310Mhz".to_owned(),
+                    "16.0GT/s, x16 619Mhz".to_owned(),
+                ],
+                active: Some(1),
+            },
+            levels
+        );
+    }
+
+    #[test]
+    fn parse_clock_levels_ignores_deep_sleep() {
+        let levels = GpuHandle::parse_clock_levels::<u64>(
+            "\
+S: 19Mhz *
+0: 615Mhz
+1: 800Mhz
+2: 888Mhz
+3: 1000Mhz",
+            PowerLevelKind::CoreClock,
+        )
+        .unwrap();
+
+        assert_eq!(
+            PowerLevels {
+                levels: vec![615, 800, 888, 1000],
+                active: None,
+            },
+            levels
+        );
     }
 }

--- a/src/gpu_handle/mod.rs
+++ b/src/gpu_handle/mod.rs
@@ -210,6 +210,14 @@ impl GpuHandle {
             let mut invalid_active = false;
 
             for mut line in content.trim().split('\n') {
+                if line
+                    .split(':')
+                    .next()
+                    .is_some_and(|identifier| identifier.trim().eq_ignore_ascii_case("S"))
+                {
+                    continue;
+                }
+
                 if let Some(stripped) = line.strip_suffix('*') {
                     line = stripped;
 

--- a/src/gpu_handle/mod.rs
+++ b/src/gpu_handle/mod.rs
@@ -199,6 +199,7 @@ impl GpuHandle {
 
     /// Retuns the list of power levels and index of the currently active level for a given kind of power state.
     /// `T` is the type that values should be deserialized into.
+    /// https://docs.kernel.org/gpu/amdgpu/thermal.html#pp-dpm
     pub fn get_clock_levels<T>(&self, kind: PowerLevelKind) -> Result<PowerLevels<T>>
     where
         T: FromStr,
@@ -859,6 +860,29 @@ S: 19Mhz *
         assert_eq!(
             PowerLevels {
                 levels: vec![615, 800, 888, 1000],
+                active: None,
+            },
+            levels
+        );
+    }
+
+    #[test]
+    fn parse_clock_levels_ignores_duplicate_active_markers() {
+        // driver tries to match active state by clocks value,
+        // which leads to duplicate active markers when there are multiple states with the same clocs
+        let levels = GpuHandle::parse_clock_levels::<u64>(
+            "\
+0: 400Mhz
+1: 600Mhz
+2: 687Mhz *
+3: 687Mhz *",
+            PowerLevelKind::CoreClock,
+        )
+        .unwrap();
+
+        assert_eq!(
+            PowerLevels {
+                levels: vec![400, 600, 687, 687],
                 active: None,
             },
             levels

--- a/src/gpu_handle/mod.rs
+++ b/src/gpu_handle/mod.rs
@@ -210,18 +210,14 @@ impl GpuHandle {
             let mut invalid_active = false;
 
             for mut line in content.trim().split('\n') {
-                if line
-                    .split(':')
-                    .next()
-                    .is_some_and(|identifier| identifier.trim().eq_ignore_ascii_case("S"))
-                {
-                    continue;
-                }
-
                 if let Some(stripped) = line.strip_suffix('*') {
                     line = stripped;
 
                     if let Some(identifier) = stripped.split(':').next() {
+                        if identifier.trim().eq_ignore_ascii_case("S") {
+                            continue;
+                        }
+
                         if !invalid_active {
                             if active.is_some() {
                                 active = None;


### PR DESCRIPTION
I think I found the cause of https://github.com/ilya-zlobintsev/LACT/issues/994
in the example here - https://docs.kernel.org/gpu/amdgpu/thermal.html#pp-dpm
If deep sleep is applied to a clock, the level will be denoted by a special level ‘S:’ E.g.,
```
S: 19Mhz *
0: 615Mhz
1: 800Mhz
2: 888Mhz
3: 1000Mhz
```


quick workaround would be to just ignore this line for now.
Other ideas - use some big constant int, so we could parse on the client that this is deep sleep state.
Or a proper solution where we break API and change active prop to string