### PR TITLE
feat: add support for (S) deep-sleep power level

### DIFF
--- a/src/gpu_handle/mod.rs
+++ b/src/gpu_handle/mod.rs
@@ -6,7 +6,7 @@ mod power_levels;
 pub mod fan_control;
 pub mod power_profile_mode;
 
-pub use power_levels::{PowerLevel, PowerLevelKind, PowerLevels, PowerLevelsActiveId};
+pub use power_levels::{PowerLevel, PowerLevelKind, PowerLevels, PowerLevelId};
 
 use self::fan_control::{FanCurve, FanCurveRanges, FanInfo};
 use crate::{
@@ -226,8 +226,8 @@ impl GpuHandle {
 
             if let Some((identifier, s)) = line.split_once(':') {
                 let id = match identifier.trim() {
-                    "S" => PowerLevelsActiveId::Sleep,
-                    identifier => PowerLevelsActiveId::Index(
+                    "S" => PowerLevelId::Sleep,
+                    identifier => PowerLevelId::Index(
                         identifier
                             .parse()
                             .context("Unexpected power level identifier")?,
@@ -805,19 +805,19 @@ impl CommitHandle {
 
 #[cfg(test)]
 mod tests {
-    use super::{GpuHandle, PowerLevel, PowerLevelKind, PowerLevels, PowerLevelsActiveId};
+    use super::{GpuHandle, PowerLevel, PowerLevelKind, PowerLevels, PowerLevelId};
     use pretty_assertions::assert_eq;
 
     fn level<T>(id: u8, value: T) -> PowerLevel<T> {
         PowerLevel {
-            id: PowerLevelsActiveId::Index(id),
+            id: PowerLevelId::Index(id),
             value,
         }
     }
 
     fn sleep<T>(value: T) -> PowerLevel<T> {
         PowerLevel {
-            id: PowerLevelsActiveId::Sleep,
+            id: PowerLevelId::Sleep,
             value,
         }
     }
@@ -835,7 +835,7 @@ mod tests {
         assert_eq!(
             PowerLevels {
                 levels: vec![level(0, 500), level(1, 2124)],
-                active: Some(PowerLevelsActiveId::Index(1)),
+                active: Some(PowerLevelId::Index(1)),
             },
             levels
         );
@@ -857,7 +857,7 @@ mod tests {
                     level(0, "2.5GT/s, x1 310Mhz".to_owned()),
                     level(1, "16.0GT/s, x16 619Mhz".to_owned()),
                 ],
-                active: Some(PowerLevelsActiveId::Index(1)),
+                active: Some(PowerLevelId::Index(1)),
             },
             levels
         );
@@ -885,7 +885,7 @@ S: 19Mhz *
                     level(2, 888),
                     level(3, 1000)
                 ],
-                active: Some(PowerLevelsActiveId::Sleep),
+                active: Some(PowerLevelId::Sleep),
             },
             levels
         );
@@ -913,7 +913,7 @@ S: 19Mhz
                     level(2, 888),
                     level(3, 1000)
                 ],
-                active: Some(PowerLevelsActiveId::Index(0)),
+                active: Some(PowerLevelId::Index(0)),
             },
             levels
         );

--- a/src/gpu_handle/mod.rs
+++ b/src/gpu_handle/mod.rs
@@ -6,7 +6,7 @@ mod power_levels;
 pub mod fan_control;
 pub mod power_profile_mode;
 
-pub use power_levels::{PowerLevelKind, PowerLevels};
+pub use power_levels::{PowerLevel, PowerLevelKind, PowerLevels, PowerLevelsActiveId};
 
 use self::fan_control::{FanCurve, FanCurveRanges, FanInfo};
 use crate::{
@@ -218,30 +218,32 @@ impl GpuHandle {
         let mut active = None;
         let mut invalid_active = false;
 
-        for mut line in content.trim().split('\n') {
-            if let Some(stripped) = line.strip_suffix('*') {
-                line = stripped;
+        for line in content.trim().split('\n') {
+            let (line, is_active) = match line.strip_suffix('*') {
+                Some(stripped) => (stripped, true),
+                None => (line, false),
+            };
 
-                if let Some(identifier) = stripped.split(':').next() {
-                    if identifier.trim().eq_ignore_ascii_case("S") {
-                        continue;
-                    }
-
-                    if !invalid_active {
-                        if active.is_some() {
-                            active = None;
-                            invalid_active = true;
-                        } else {
-                            let idx = identifier
-                                .trim()
-                                .parse()
-                                .context("Unexpected power level identifier")?;
-                            active = Some(idx);
-                        }
+            if let Some((identifier, s)) = line.split_once(':') {
+                let id = match identifier.trim() {
+                    "S" => PowerLevelsActiveId::Sleep,
+                    identifier => PowerLevelsActiveId::Index(
+                        identifier
+                            .parse()
+                            .context("Unexpected power level identifier")?,
+                    ),
+                };
+                // https://gitlab.freedesktop.org/drm/amd/-/work_items/5296
+                // handles duplicate active level lines
+                if is_active && !invalid_active {
+                    if active.is_some() {
+                        active = None;
+                        invalid_active = true;
+                    } else {
+                        active = Some(id);
                     }
                 }
-            }
-            if let Some(s) = line.split(':').next_back() {
+
                 let parse_result = if let Some(suffix) = kind.value_suffix() {
                     let raw_value = s.trim().to_lowercase();
                     let value =
@@ -261,7 +263,10 @@ impl GpuHandle {
                     msg: format!("Could not deserialize power level value: {err}"),
                     line: levels.len() + 1,
                 })?;
-                levels.push(parsed_value);
+                levels.push(PowerLevel {
+                    id,
+                    value: parsed_value,
+                });
             }
         }
 
@@ -800,8 +805,22 @@ impl CommitHandle {
 
 #[cfg(test)]
 mod tests {
-    use super::{GpuHandle, PowerLevelKind, PowerLevels};
+    use super::{GpuHandle, PowerLevel, PowerLevelKind, PowerLevels, PowerLevelsActiveId};
     use pretty_assertions::assert_eq;
+
+    fn level<T>(id: u8, value: T) -> PowerLevel<T> {
+        PowerLevel {
+            id: PowerLevelsActiveId::Index(id),
+            value,
+        }
+    }
+
+    fn sleep<T>(value: T) -> PowerLevel<T> {
+        PowerLevel {
+            id: PowerLevelsActiveId::Sleep,
+            value,
+        }
+    }
 
     #[test]
     fn parse_clock_levels_with_suffix() {
@@ -815,8 +834,8 @@ mod tests {
 
         assert_eq!(
             PowerLevels {
-                levels: vec![500, 2124],
-                active: Some(1),
+                levels: vec![level(0, 500), level(1, 2124)],
+                active: Some(PowerLevelsActiveId::Index(1)),
             },
             levels
         );
@@ -835,17 +854,17 @@ mod tests {
         assert_eq!(
             PowerLevels {
                 levels: vec![
-                    "2.5GT/s, x1 310Mhz".to_owned(),
-                    "16.0GT/s, x16 619Mhz".to_owned(),
+                    level(0, "2.5GT/s, x1 310Mhz".to_owned()),
+                    level(1, "16.0GT/s, x16 619Mhz".to_owned()),
                 ],
-                active: Some(1),
+                active: Some(PowerLevelsActiveId::Index(1)),
             },
             levels
         );
     }
 
     #[test]
-    fn parse_clock_levels_ignores_deep_sleep() {
+    fn parse_clock_levels_marks_deep_sleep_active() {
         let levels = GpuHandle::parse_clock_levels::<u64>(
             "\
 S: 19Mhz *
@@ -859,8 +878,42 @@ S: 19Mhz *
 
         assert_eq!(
             PowerLevels {
-                levels: vec![615, 800, 888, 1000],
-                active: None,
+                levels: vec![
+                    sleep(19),
+                    level(0, 615),
+                    level(1, 800),
+                    level(2, 888),
+                    level(3, 1000)
+                ],
+                active: Some(PowerLevelsActiveId::Sleep),
+            },
+            levels
+        );
+    }
+
+    #[test]
+    fn parse_clock_levels_marks_deep_sleep_inactive() {
+        let levels = GpuHandle::parse_clock_levels::<u64>(
+            "\
+S: 19Mhz
+0: 615Mhz *
+1: 800Mhz
+2: 888Mhz
+3: 1000Mhz",
+            PowerLevelKind::CoreClock,
+        )
+        .unwrap();
+
+        assert_eq!(
+            PowerLevels {
+                levels: vec![
+                    sleep(19),
+                    level(0, 615),
+                    level(1, 800),
+                    level(2, 888),
+                    level(3, 1000)
+                ],
+                active: Some(PowerLevelsActiveId::Index(0)),
             },
             levels
         );
@@ -882,7 +935,7 @@ S: 19Mhz *
 
         assert_eq!(
             PowerLevels {
-                levels: vec![400, 600, 687, 687],
+                levels: vec![level(0, 400), level(1, 600), level(2, 687), level(3, 687)],
                 active: None,
             },
             levels

--- a/src/gpu_handle/power_levels.rs
+++ b/src/gpu_handle/power_levels.rs
@@ -6,16 +6,31 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PowerLevels<T> {
     /// List of possible levels.
-    pub levels: Vec<T>,
+    pub levels: Vec<PowerLevel<T>>,
     /// The currently active level.
-    pub active: Option<usize>,
+    pub active: Option<PowerLevelsActiveId>,
 }
 
 impl<T> PowerLevels<T> {
     /// Gets the currently active level value.
     pub fn active_level(&self) -> Option<&T> {
-        self.active.and_then(|active| self.levels.get(active))
+        self.active.and_then(|active| {
+            self.levels
+                .iter()
+                .find(|level| level.id == active)
+                .map(|level| &level.value)
+        })
     }
+}
+
+/// Single power level row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PowerLevel<T> {
+    /// Printed sysfs level identifier.
+    pub id: PowerLevelsActiveId,
+    /// Level value.
+    pub value: T,
 }
 
 macro_rules! impl_get_clocks_levels {
@@ -25,6 +40,16 @@ macro_rules! impl_get_clocks_levels {
             self.get_clock_levels($level)
         }
     };
+}
+
+/// Identifier of a power level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PowerLevelsActiveId {
+    /// Numeric power level index.
+    Index(u8),
+    /// Deep sleep power level.
+    Sleep,
 }
 
 /// Type of a power level.

--- a/src/gpu_handle/power_levels.rs
+++ b/src/gpu_handle/power_levels.rs
@@ -8,7 +8,7 @@ pub struct PowerLevels<T> {
     /// List of possible levels.
     pub levels: Vec<PowerLevel<T>>,
     /// The currently active level.
-    pub active: Option<PowerLevelsActiveId>,
+    pub active: Option<PowerLevelId>,
 }
 
 impl<T> PowerLevels<T> {
@@ -28,7 +28,7 @@ impl<T> PowerLevels<T> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PowerLevel<T> {
     /// Printed sysfs level identifier.
-    pub id: PowerLevelsActiveId,
+    pub id: PowerLevelId,
     /// Level value.
     pub value: T,
 }
@@ -45,7 +45,7 @@ macro_rules! impl_get_clocks_levels {
 /// Identifier of a power level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PowerLevelsActiveId {
+pub enum PowerLevelId {
     /// Numeric power level index.
     Index(u8),
     /// Deep sleep power level.

--- a/tests/rx580.rs
+++ b/tests/rx580.rs
@@ -2,7 +2,7 @@ mod sysfs;
 mod utils;
 
 use amdgpu_sysfs::{
-    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevels, PowerLevelsActiveId},
+    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevelId, PowerLevels},
     hw_mon::{HwMon, Temperature},
 };
 use std::collections::HashMap;
@@ -49,7 +49,7 @@ test_with_handle! {
                 p_level(6, 1300),
                 p_level(7, 1366)
             ],
-            active: Some(PowerLevelsActiveId::Index(2))
+            active: Some(PowerLevelId::Index(2))
         })
     },
     pp_dpm_mclk => {
@@ -60,7 +60,7 @@ test_with_handle! {
                 p_level(1, 1000),
                 p_level(2, 1750),
             ],
-            active: Some(PowerLevelsActiveId::Index(2))
+            active: Some(PowerLevelId::Index(2))
         })
     },
     pp_dpm_pcie => {
@@ -70,7 +70,7 @@ test_with_handle! {
                 p_level(0, "2.5GT/s, x8".to_owned()),
                 p_level(1, "8.0GT/s, x16".to_owned())
             ].to_vec(),
-            active: Some(PowerLevelsActiveId::Index(1))
+            active: Some(PowerLevelId::Index(1))
         })
     }
 }

--- a/tests/rx580.rs
+++ b/tests/rx580.rs
@@ -1,10 +1,12 @@
 mod sysfs;
+mod utils;
 
 use amdgpu_sysfs::{
-    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevels},
+    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevels, PowerLevelsActiveId},
     hw_mon::{HwMon, Temperature},
 };
 use std::collections::HashMap;
+use utils::p_level;
 
 test_with_handle! {
     "rx580",
@@ -38,37 +40,37 @@ test_with_handle! {
         GpuHandle::get_core_clock_levels,
         Ok(PowerLevels {
             levels: vec![
-                300,
-                600,
-                900,
-                1145,
-                1215,
-                1257,
-                1300,
-                1366
+                p_level(0, 300),
+                p_level(1, 600),
+                p_level(2, 900),
+                p_level(3, 1145),
+                p_level(4, 1215),
+                p_level(5, 1257),
+                p_level(6, 1300),
+                p_level(7, 1366)
             ],
-            active: Some(2)
+            active: Some(PowerLevelsActiveId::Index(2))
         })
     },
     pp_dpm_mclk => {
         GpuHandle::get_memory_clock_levels,
         Ok(PowerLevels {
             levels: vec![
-                300,
-                1000,
-                1750,
+                p_level(0, 300),
+                p_level(1, 1000),
+                p_level(2, 1750),
             ],
-            active: Some(2)
+            active: Some(PowerLevelsActiveId::Index(2))
         })
     },
     pp_dpm_pcie => {
         GpuHandle::get_pcie_clock_levels,
         Ok(PowerLevels {
             levels: [
-                "2.5GT/s, x8",
-                "8.0GT/s, x16"
-            ].map(str::to_owned).to_vec(),
-            active: Some(1)
+                p_level(0, "2.5GT/s, x8".to_owned()),
+                p_level(1, "8.0GT/s, x16".to_owned())
+            ].to_vec(),
+            active: Some(PowerLevelsActiveId::Index(1))
         })
     }
 }

--- a/tests/rx6900xt.rs
+++ b/tests/rx6900xt.rs
@@ -1,4 +1,4 @@
-use amdgpu_sysfs::gpu_handle::{GpuHandle, PowerLevels, PowerLevelsActiveId};
+use amdgpu_sysfs::gpu_handle::{GpuHandle, PowerLevelId, PowerLevels};
 use utils::p_level;
 
 mod sysfs;
@@ -13,7 +13,7 @@ test_with_handle! {
                 p_level(0, 500),
                 p_level(1, 2660)
             ],
-            active: Some(PowerLevelsActiveId::Index(0))
+            active: Some(PowerLevelId::Index(0))
         })
     },
 }

--- a/tests/rx6900xt.rs
+++ b/tests/rx6900xt.rs
@@ -1,6 +1,8 @@
-use amdgpu_sysfs::gpu_handle::{GpuHandle, PowerLevels};
+use amdgpu_sysfs::gpu_handle::{GpuHandle, PowerLevels, PowerLevelsActiveId};
+use utils::p_level;
 
 mod sysfs;
+mod utils;
 
 test_with_handle! {
     "rx6900xt",
@@ -8,10 +10,10 @@ test_with_handle! {
         GpuHandle::get_core_clock_levels,
         Ok(PowerLevels {
             levels: vec![
-                500,
-                2660
+                p_level(0, 500),
+                p_level(1, 2660)
             ],
-            active: Some(0)
+            active: Some(PowerLevelsActiveId::Index(0))
         })
     },
 }

--- a/tests/rx6950xt.rs
+++ b/tests/rx6950xt.rs
@@ -1,6 +1,8 @@
 mod sysfs;
+mod utils;
 
 use amdgpu_sysfs::gpu_handle::{GpuHandle, PowerLevels};
+use utils::p_level;
 
 test_with_handle! {
     "rx6950xt",
@@ -8,7 +10,7 @@ test_with_handle! {
         GpuHandle::get_core_clock_levels,
         Ok(PowerLevels {
             levels: vec![
-                0, 0
+                p_level(0, 0), p_level(1, 0)
             ],
             active: None,
         })

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,8 +1,8 @@
-use amdgpu_sysfs::gpu_handle::{PowerLevel, PowerLevelsActiveId};
+use amdgpu_sysfs::gpu_handle::{PowerLevel, PowerLevelId};
 
 pub fn p_level<T>(id: u8, value: T) -> PowerLevel<T> {
     PowerLevel {
-        id: PowerLevelsActiveId::Index(id),
+        id: PowerLevelId::Index(id),
         value,
     }
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,8 @@
+use amdgpu_sysfs::gpu_handle::{PowerLevel, PowerLevelsActiveId};
+
+pub fn p_level<T>(id: u8, value: T) -> PowerLevel<T> {
+    PowerLevel {
+        id: PowerLevelsActiveId::Index(id),
+        value,
+    }
+}

--- a/tests/vega56.rs
+++ b/tests/vega56.rs
@@ -1,10 +1,12 @@
 mod sysfs;
+mod utils;
 
 use amdgpu_sysfs::{
-    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevels},
+    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevels, PowerLevelsActiveId},
     hw_mon::{HwMon, Temperature},
 };
 use std::collections::HashMap;
+use utils::p_level;
 
 test_with_handle! {
     "vega56",
@@ -41,37 +43,37 @@ test_with_handle! {
         GpuHandle::get_core_clock_levels,
         Ok(PowerLevels {
             levels: vec![
-                852,
-                991,
-                1138,
-                1269,
-                1312,
-                1474,
-                1538,
-                1590
+                p_level(0, 852),
+                p_level(1, 991),
+                p_level(2, 1138),
+                p_level(3, 1269),
+                p_level(4, 1312),
+                p_level(5, 1474),
+                p_level(6, 1538),
+                p_level(7, 1590)
             ],
-            active: Some(0)
+            active: Some(PowerLevelsActiveId::Index(0))
         })
     },
     pp_dpm_mclk => {
         GpuHandle::get_memory_clock_levels,
         Ok(PowerLevels {
             levels: vec![
-                167,
-                500,
-                700,
-                920,
+                p_level(0, 167),
+                p_level(1, 500),
+                p_level(2, 700),
+                p_level(3, 920),
             ],
-            active: Some(0)
+            active: Some(PowerLevelsActiveId::Index(0))
         })
     },
     pp_dpm_pcie => {
         GpuHandle::get_pcie_clock_levels,
         Ok(PowerLevels {
             levels: [
-                "8.0GT/s, x16",
-                "8.0GT/s, x16"
-            ].map(str::to_owned).to_vec(),
+                p_level(0, "8.0GT/s, x16".to_owned()),
+                p_level(1, "8.0GT/s, x16".to_owned())
+            ].to_vec(),
             active: None
         })
     }

--- a/tests/vega56.rs
+++ b/tests/vega56.rs
@@ -2,7 +2,7 @@ mod sysfs;
 mod utils;
 
 use amdgpu_sysfs::{
-    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevels, PowerLevelsActiveId},
+    gpu_handle::{GpuHandle, PerformanceLevel, PowerLevels, PowerLevelId},
     hw_mon::{HwMon, Temperature},
 };
 use std::collections::HashMap;
@@ -52,7 +52,7 @@ test_with_handle! {
                 p_level(6, 1538),
                 p_level(7, 1590)
             ],
-            active: Some(PowerLevelsActiveId::Index(0))
+            active: Some(PowerLevelId::Index(0))
         })
     },
     pp_dpm_mclk => {
@@ -64,7 +64,7 @@ test_with_handle! {
                 p_level(2, 700),
                 p_level(3, 920),
             ],
-            active: Some(PowerLevelsActiveId::Index(0))
+            active: Some(PowerLevelId::Index(0))
         })
     },
     pp_dpm_pcie => {


### PR DESCRIPTION
I refactored the parse function a bit, because I found It confusing. Specifically is_active is now more explicit 